### PR TITLE
Normalized request paths

### DIFF
--- a/framework/Http/Request.php
+++ b/framework/Http/Request.php
@@ -34,9 +34,9 @@ class Request
     public function fullpath(): string
     {
         $path = explode('?', $_SERVER['REQUEST_URI'])[0];
-        $path = rtrim($path, '/');
+        $path = trim($path, '/');
 
-        return $path !== '' ? $path : '/';
+        return '/' . $path;
     }
 
     public function path(): string
@@ -46,7 +46,7 @@ class Request
             strlen($this->basepath)
         );
 
-        return $path !== '' ? $path : '/';
+        return '/' . trim($path, '/');
     }
 
     public function segments(int $index = null)


### PR DESCRIPTION
When the request handler predicts request path, it should normalize it to contain a forward slash at the beginning of the path.
So for example, if the request URI is `app.dev/users`, the request path should be `/users`.