### PR TITLE
Bug fix relative URL utility function

### DIFF
--- a/framework/utilities.php
+++ b/framework/utilities.php
@@ -21,7 +21,8 @@ if (!function_exists('url')) {
     function url() {
         $path = implode('/', func_get_args());
         $url = app('request')->basepath() . '/' . $path;
-        return $url;
+        
+        return '/' . trim($url, '/');
     }
 }
 


### PR DESCRIPTION
Trim the generated relative URL to prevent extra forward slashes.