### PR TITLE
chore: restructure language configuration and update default APP_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.5] - 2026-07-02
+
+- **chore:** Update `config/app.php` to support language configuration.
+
 ## [0.9.4] - 2026-06-22
 
 - **chore:** Relax framework constraint from `^0.9` to `~0.9` so new projects automatically get framework v0.10.0 and future 0.x releases without updating the template.

--- a/config/app.php
+++ b/config/app.php
@@ -3,9 +3,12 @@
 return [
     'app' => [
         'env' => get_env('APP_ENV', 'development'),
-        'url' => get_env('APP_URL', 'http://localhost'),
+        'url' => get_env('APP_URL', 'http://127.0.0.1'),
         'timezone' => 'UTC',
-        'locale' => 'en',
         'key' => get_env('APP_KEY'),
-    ]
+        'lang' => [
+            'default' => get_env('APP_LOCALE', 'en'),
+            'fallback' => get_env('APP_FALLBACK_LOCALE', 'en'),
+        ],
+    ],
 ];


### PR DESCRIPTION
- Moved locale configuration to nested 'lang' array with 'default' and 'fallback' keys
- Added APP_LOCALE and APP_FALLBACK_LOCALE environment variable support
- Changed default APP_URL from 'http://localhost' to 'http://127.0.0.1'